### PR TITLE
fix: modified pattern for vimeo videos...

### DIFF
--- a/meta-ographr_index.php
+++ b/meta-ographr_index.php
@@ -1642,7 +1642,7 @@ class OGraphr_Core {
 									'name' => 'Vimeo',
 									'patterns' => array(
 										'#<object[^>]+>.+?https?://vimeo.com/moogaloop.swf\?clip_id=([A-Za-z0-9\-_]+)&.+?</object>#s',
-										'#https?://player.vimeo.com/video/([0-9]+)#s',
+										'#https?:|//player.vimeo.com/video/([0-9]+)#s',
 										'/\[vimeo.*?]https?:\/\/w*.?vimeo.com\/([0-9]+)\[\/vimeo]/i',
 										'/^(?:href\=){0,1}https?:\/\/w*.?vimeo.com\/([A-Za-z0-9\-_]+)/i',
 									),


### PR DESCRIPTION
... so that relative URLs with "same protocol" also work.

Wordpress embeds vimeo videos like that:

```
<iframe src="//player.vimeo.com/video/14965306" width="640" height="360" frameborder="0" title="The Notwist - On Off The Record" webkitallowfullscreen mozallowfullscreen allowfullscreen>
```

With this modified pattern these embeds are also recognized by your great plugin.
